### PR TITLE
Don't automatically re-sort collections

### DIFF
--- a/lib/Malarzm/Collections/SortedCollection.php
+++ b/lib/Malarzm/Collections/SortedCollection.php
@@ -28,12 +28,16 @@ abstract class SortedCollection extends AbstractCollection
      *
      * @param array $elements
      * @param callable $sort uasort is used by default
+     * @param boolean $sortElements If true, elements will be sorted when creating the collection
      */
-    public function __construct(array $elements = [], callable $sort = null)
+    public function __construct(array $elements = [], callable $sort = null, $sortElements = true)
     {
         parent::__construct($elements);
         $this->sort = $sort !== null ? $sort : 'uasort';
-        call_user_func_array($this->sort, [&$this->elements, [$this, 'compare']]);
+
+        if ($sortElements) {
+            call_user_func_array($this->sort, [&$this->elements, [$this, 'compare']]);
+        }
     }
 
     /**
@@ -52,7 +56,7 @@ abstract class SortedCollection extends AbstractCollection
      */
     public function filter(Closure $p)
     {
-        return new static(array_filter($this->elements, $p), $this->sort);
+        return new static(array_filter($this->elements, $p), $this->sort, false);
     }
 
     /**
@@ -73,7 +77,7 @@ abstract class SortedCollection extends AbstractCollection
      */
     public function map(Closure $func)
     {
-        return new static(array_map($func, $this->elements), $this->sort);
+        return new static(array_map($func, $this->elements), $this->sort, false);
     }
 
     /**
@@ -91,7 +95,7 @@ abstract class SortedCollection extends AbstractCollection
             }
         }
 
-        return array(new static($matches, $this->sort), new static($noMatches, $this->sort));
+        return array(new static($matches, $this->sort, false), new static($noMatches, $this->sort, false));
     }
 
     /**

--- a/lib/Malarzm/Collections/SortedList.php
+++ b/lib/Malarzm/Collections/SortedList.php
@@ -2,6 +2,8 @@
 
 namespace Malarzm\Collections;
 
+use Closure;
+
 abstract class SortedList extends ListArray
 {
     /**
@@ -18,11 +20,15 @@ abstract class SortedList extends ListArray
      * Initializes SortedList ensuring that elements are in fact a sorted list.
      *
      * @param array $elements
+     * @param boolean $sortElements If true, elements will be sorted when creating the list
      */
-    public function __construct(array $elements = [])
+    public function __construct(array $elements = [], $sortElements = true)
     {
         parent::__construct($elements);
-        usort($this->elements, [ $this, 'compare' ]);
+
+        if ($sortElements) {
+            usort($this->elements, [ $this, 'compare' ]);
+        }
     }
 
     /**
@@ -94,5 +100,39 @@ abstract class SortedList extends ListArray
     {
         parent::set($key, $value);
         usort($this->elements, [ $this, 'compare' ]);
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function map(Closure $func)
+    {
+        return new static(array_map($func, $this->elements), false);
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function filter(Closure $p)
+    {
+        return new static(array_filter($this->elements, $p), false);
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function partition(Closure $p)
+    {
+        $matches = $noMatches = array();
+
+        foreach ($this->elements as $key => $element) {
+            if ($p($key, $element)) {
+                $matches[$key] = $element;
+            } else {
+                $noMatches[$key] = $element;
+            }
+        }
+
+        return array(new static($matches, false), new static($noMatches, false));
     }
 }

--- a/tests/Malarzm/Tests/Collections/SortedCollectionTest.php
+++ b/tests/Malarzm/Tests/Collections/SortedCollectionTest.php
@@ -41,6 +41,24 @@ class SortedCollectionTest extends BaseTest
         ++$i; unset($c[1]);
         $this->assertEquals($i, $spy->cnt);
     }
+
+    public function testMapKeepsSortOrder()
+    {
+        $collection = new SortedObjectCollection();
+        $collection->add((object) ['sortOrder' => 1]);
+        $collection->add((object) ['sortOrder' => 2]);
+        $collection->add((object) ['sortOrder' => 3]);
+
+        $newCollection = $collection->map(function ($object) { return (array) $object; });
+
+        $expected = [
+            ['sortOrder' => 1],
+            ['sortOrder' => 2],
+            ['sortOrder' => 3],
+        ];
+
+        $this->assertSame($expected, $newCollection->toArray());
+    }
 }
 
 class SortedIntCollection extends SortedCollection
@@ -50,6 +68,28 @@ class SortedIntCollection extends SortedCollection
         if ($a > $b) {
             return 1;
         } elseif ($a === $b) {
+            return 0;
+        } else {
+            return -1;
+        }
+    }
+}
+
+class SortedObjectCollection extends SortedCollection
+{
+    public function compare($a, $b)
+    {
+        if (! $a instanceof \stdClass || ! $b instanceof \stdClass) {
+            return 0;
+        }
+
+        if (! isset($a->sortOrder, $b->sortOrder)) {
+            return 0;
+        }
+
+        if ($a->sortOrder > $b->sortOrder) {
+            return 1;
+        } elseif ($a->sortOrder === $b->sortOrder) {
             return 0;
         } else {
             return -1;

--- a/tests/Malarzm/Tests/Collections/SortedListTest.php
+++ b/tests/Malarzm/Tests/Collections/SortedListTest.php
@@ -74,6 +74,24 @@ class SortedListTest extends BaseTest
         $c[] = 10;
         $this->assertSame(5, $c->indexOf(10));
     }
+
+    public function testMapKeepsSortOrder()
+    {
+        $collection = new SortedObjectList();
+        $collection->add((object) ['sortOrder' => 1]);
+        $collection->add((object) ['sortOrder' => 2]);
+        $collection->add((object) ['sortOrder' => 3]);
+
+        $newCollection = $collection->map(function ($object) { return (array) $object; });
+
+        $expected = [
+            ['sortOrder' => 1],
+            ['sortOrder' => 2],
+            ['sortOrder' => 3],
+        ];
+
+        $this->assertSame($expected, $newCollection->toArray());
+    }
 }
 
 class SortedIntList extends SortedList
@@ -83,6 +101,28 @@ class SortedIntList extends SortedList
         if ($a > $b) {
             return 1;
         } elseif ($a === $b) {
+            return 0;
+        } else {
+            return -1;
+        }
+    }
+}
+
+class SortedObjectList extends SortedList
+{
+    public function compare($a, $b)
+    {
+        if (! $a instanceof \stdClass || ! $b instanceof \stdClass) {
+            return 0;
+        }
+
+        if (! isset($a->sortOrder, $b->sortOrder)) {
+            return 0;
+        }
+
+        if ($a->sortOrder > $b->sortOrder) {
+            return 1;
+        } elseif ($a->sortOrder === $b->sortOrder) {
             return 0;
         } else {
             return -1;


### PR DESCRIPTION
When using `SortedCollection` or `SortedList` to store objects, calling `map()` on the list with a callback that returns a different object will cause unwanted order in the lists due to the sort function potentially checking for objects. To avoid this, the `map()` function creates a new instance of itself without sorting the elements in the constructor.

Additionally, the same behavior is used in the `filter()` and `partition()` methods since we can assume that the list has been previously sorted and does not need to be sorted again. This increases performance when applying a callback to a large list.
