### PR TITLE
Implement ArrayCollection

### DIFF
--- a/lib/Malarzm/Collections/ArrayCollection.php
+++ b/lib/Malarzm/Collections/ArrayCollection.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Malarzm\Collections;
+
+class ArrayCollection extends AbstractCollection
+{
+    /**
+     * @inheritdoc
+     */
+    public function add($element)
+    {
+        $this->elements[] = $element;
+
+        return true;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function remove($key)
+    {
+        if ( ! isset($this->elements[$key]) && ! array_key_exists($key, $this->elements)) {
+            return null;
+        }
+
+        $removed = $this->elements[$key];
+        unset($this->elements[$key]);
+
+        return $removed;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function removeElement($element)
+    {
+        $key = array_search($element, $this->elements, true);
+
+        if ($key === false) {
+            return false;
+        }
+
+        unset($this->elements[$key]);
+
+        return true;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function set($key, $value)
+    {
+        $this->elements[$key] = $value;
+    }
+}

--- a/tests/Malarzm/Tests/Collections/ArrayCollectionTest.php
+++ b/tests/Malarzm/Tests/Collections/ArrayCollectionTest.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Malarzm\Collections\Tests;
+
+use Malarzm\Collections\ArrayCollection;
+
+class ArrayCollectionTest extends BaseTest
+{
+    public function provideCollection()
+    {
+        $associative = [ 'foo' => 1, 'bar' => 2, 7 ];
+        return [
+            [ new ArrayCollection([ 5, 7, 9 ]), [ 5, 7, 9] ],
+            [ new ArrayCollection($associative), $associative ],
+        ];
+    }
+
+    public function testRemove()
+    {
+        $elements = array(1, 'A' => 'a', 2, 'B' => 'b', 3);
+        $collection = new ArrayCollection($elements);
+
+        $this->assertEquals(1, $collection->remove(0));
+        unset($elements[0]);
+
+        $this->assertEquals(null, $collection->remove('non-existent'));
+        unset($elements['non-existent']);
+
+        $this->assertEquals(2, $collection->remove(1));
+        unset($elements[1]);
+
+        $this->assertEquals('a', $collection->remove('A'));
+        unset($elements['A']);
+
+        $this->assertEquals($elements, $collection->toArray());
+    }
+
+    public function testRemoveElement()
+    {
+        $elements = array(1, 'A' => 'a', 2, 'B' => 'b', 3, 'A2' => 'a', 'B2' => 'b');
+        $collection = new ArrayCollection($elements);
+
+        $this->assertTrue($collection->removeElement(1));
+        unset($elements[0]);
+
+        $this->assertFalse($collection->removeElement('non-existent'));
+
+        $this->assertTrue($collection->removeElement('a'));
+        unset($elements['A']);
+
+        $this->assertTrue($collection->removeElement('a'));
+        unset($elements['A2']);
+
+        $this->assertEquals($elements, $collection->toArray());
+    }
+}


### PR DESCRIPTION
Closes #9 

Implementation is exactly the same as Doctrine's, the only difference is that here collection's elements are `protected` as that's what `AbstractCollection` was defining. I also think this was the original reason for submitting #9.